### PR TITLE
create_react_component 스크립트 추가

### DIFF
--- a/client/scripts/create_react_component.sh
+++ b/client/scripts/create_react_component.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+if [ -z "$*" ]; then
+ echo "put argument with ComponentName"
+ exit 0
+
+fi
+
+FOLDER="components"
+FILE_NAME=$1
+FIRST_CAP="$(tr '[:lower:]' '[:upper:]' <<< ${FOLDER:0:1})${FOLDER:1}"
+APPEND=`echo "${FIRST_CAP%?}"`
+
+echo `mkdir src/${FOLDER}/${FILE_NAME}`
+
+# react file
+echo `echo "import React from 'react';
+import styled from 'styled-components';
+
+interface ${FILE_NAME}Props {
+
+}
+
+const ${FILE_NAME} = ({} : ${FILE_NAME}Props) => {
+	return (
+    <${FILE_NAME}Container>
+      ${FILE_NAME}
+    </${FILE_NAME}Container>
+  )
+};
+
+export default ${FILE_NAME};
+
+const ${FILE_NAME}Container = styled.div\\\`\\\`;
+" > src/${FOLDER}/${FILE_NAME}/${FILE_NAME}.tsx`


### PR DESCRIPTION
## 요약
create_react_component 스크립트 추가

## 작업내용 및 설명
- 루트/scripts에 create_react_component.sh 스크립트 추가
- client 디렉토리에서 `./scripts/create_react_component.sh [컴포넌트명]`을 입력하면, 리액트 컴포넌트 폴더+파일이 생성됩니다. 
- 치트키: 터미널에서 client 디렉토리로 이동 후 ->./sc 입력 -> 탭 -> c 입력 -> 탭 -> 컴포넌트명 입력 -> 엔터

## 스크린샷

https://user-images.githubusercontent.com/34447105/128635923-f5a57826-747c-407a-9234-a5443b5bf35e.mov
