### PR TITLE
api url 추가

### DIFF
--- a/client/src/apis/baseAPI.ts
+++ b/client/src/apis/baseAPI.ts
@@ -2,8 +2,8 @@ import Axios from 'axios';
 
 export const TOKEN_KEY = 'Authorization';
 
-const devURL = 'http://localhost:';
-const prodURL = '';
+const devURL = 'http://3.36.113.129:';
+const prodURL = 'http://3.36.113.129:';
 const PORT = 4000;
 
 export const baseURL = process.env.NODE_ENV === 'production' ? prodURL : devURL;


### PR DESCRIPTION
## 요약
api url 추가

## 작업내용 및 설명
- 기존 서버 url로 사용되고 있던 localhost를 aws 서버 api url로 변경

## 스크린샷
없음